### PR TITLE
move all urls from devc to geeksblabla

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </h2>
 <hr />
 
-StateOfDev.ma is a survey centered around software developers in Morocco by DevC Morocco Community.
+StateOfDev.ma is a survey centered around software developers in Morocco by GeeksBlaBla Morocco Community.
 
 We wanted to know how we can help and support each other, and overall be able to better respond to developers evolving needs.
 
@@ -66,7 +66,7 @@ Your website is now running at `http://localhost:8888`
 
 ## 🧐 Want to contribute ?
 
-If you want to contribute check out the [help wanted](https://github.com/devC-Casa/stateofdev.ma/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+sort%3Aupdated-desc) issues for things that need fixing, or suggest some new features by opening new issues.
+If you want to contribute check out the [help wanted](https://github.com/geeksblabla/stateofdev.ma/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+sort%3Aupdated-desc) issues for things that need fixing, or suggest some new features by opening new issues.
 
 ## Licensing
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,7 +17,7 @@ module.exports = {
     banner: config.banner,
     author: {
       name: config.author,
-      minibio: `DevC Casablanca`,
+      minibio: `GeeksBlaBla`,
     },
     organization: {
       name: config.organization,

--- a/results/2020/sections/overview.mdx
+++ b/results/2020/sections/overview.mdx
@@ -25,7 +25,7 @@ Remote working has been a positive step in their career, as well as being part o
 
 ### A word about methodology
 
-As part of our core principles, all collected data is anonymized. Raw results are also available under the BY-NC-SA 2.0 license. Same thing for the website code, we put everything on [DevC-Casa GitHub organization](https://github.com/DevC-Casa/stateofdev.ma).
+As part of our core principles, all collected data is anonymized. Raw results are also available under the BY-NC-SA 2.0 license. Same thing for the website code, we put everything on [GeeksBlaBla GitHub organization](https://github.com/geeksblabla/stateofdev.ma).
 
 It’s important to note that not all fields were mandatory, so the results and graphics may not reflect the respondents’ total number for every question.
 

--- a/results/2021/sections/more.mdx
+++ b/results/2021/sections/more.mdx
@@ -9,4 +9,4 @@ position: 7
 
 <br />
 
-> [👋 Add your Insights](https://github.com/DevC-Casa/stateofdev.ma/blob/master/results/2021/sections/more.mdx)
+> [👋 Add your Insights](https://github.com/geeksblabla/stateofdev.ma/blob/master/results/2021/sections/more.mdx)

--- a/results/2021/sections/overview.mdx
+++ b/results/2021/sections/overview.mdx
@@ -25,8 +25,8 @@ Finally, we noticed this year a dip in contributions, and we learned that launch
 
 ### A word about methodology
 
-As part of our core principles, all collected data is anonymized. Raw results are also available under the BY-NC-SA 2.0 license. Same thing for the website code, we put everything on [DevC-Casa GitHub organization](https://github.com/DevC-Casa/stateofdev.ma).
+As part of our core principles, all collected data is anonymized. Raw results are also available under the BY-NC-SA 2.0 license. Same thing for the website code, we put everything on [GeeksBlaBla GitHub organization](https://github.com/geeksblabla/stateofdev.ma).
 
 It’s important to note that not all fields were mandatory, so the results and graphics may not reflect the respondents’ total number for every question.
 
-We want to thank [all our amazing contributors and everyone](https://github.com/DevC-Casa/stateofdev.ma#contributors-) who helped share the survey to get more submissions. We’re looking forward to your feedback and for you to share the results with your network.
+We want to thank [all our amazing contributors and everyone](https://github.com/geeksblabla/stateofdev.ma#contributors-) who helped share the survey to get more submissions. We’re looking forward to your feedback and for you to share the results with your network.

--- a/results/2022/sections/overview.mdx
+++ b/results/2022/sections/overview.mdx
@@ -17,7 +17,7 @@ your feedback and suggestions.
 
 ### A word about methodology
 
-At our core, we value anonymity and as such, all collected data from the survey is anonymized. Raw results and the website code are also available under the BY-NC-SA 2.0 license on the [DevC-Casa GitHub organization](https://github.com/DevC-Casa/stateofdev.ma).
+At our core, we value anonymity and as such, all collected data from the survey is anonymized. Raw results and the website code are also available under the BY-NC-SA 2.0 license on the [GeeksBlaBla GitHub organization](https://github.com/geeksblabla/stateofdev.ma).
 
 Please note that not all fields in the survey were mandatory, which may result in some results and graphics not reflecting the total number of respondents for every question.
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -39,7 +39,7 @@ export const Footer = () => {
               <li>
                 <a
                   className="hover:text-emerald-600 hover:underline"
-                  href="https://github.com/DevC-Casa/awesome-morocco"
+                  href="https://github.com/geeksblabla/awesome-morocco"
                   target="_blank"
                 >
                   awesome-morocco.dev
@@ -118,7 +118,7 @@ export const Footer = () => {
               <li>
                 <a
                   className="hover:text-emerald-600 hover:underline"
-                  href="https://github.com/devc-casa"
+                  href="https://github.com/geeksblabla"
                   target="_blank"
                 >
                   Github

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -60,7 +60,7 @@ export const Header = () => {
           </li>
           <li className="md:mr-6">
             <a
-              href="https://github.com/devc-casa/stateofdev.ma"
+              href="https://github.com/geeksblabla/stateofdev.ma"
               target="_blank"
             >
               <GithubLink />

--- a/src/components/Playground/index.js
+++ b/src/components/Playground/index.js
@@ -88,7 +88,7 @@ const useData = (year = 2022) => {
     data: questions,
     error: QErrors,
   } = useFetch(
-    `https://raw.githubusercontent.com/DevC-Casa/stateofdev.ma/master/results/${year}/data/questions.json`
+    `https://raw.githubusercontent.com/geeksblabla/stateofdev.ma/master/results/${year}/data/questions.json`
   )
 
   const {
@@ -96,7 +96,7 @@ const useData = (year = 2022) => {
     data: results,
     error,
   } = useFetch(
-    `https://raw.githubusercontent.com/DevC-Casa/stateofdev.ma/master/results/${year}/data/results.json`
+    `https://raw.githubusercontent.com/geeksblabla/stateofdev.ma/master/results/${year}/data/results.json`
   )
 
   return {

--- a/src/components/Results/Actions.js
+++ b/src/components/Results/Actions.js
@@ -23,7 +23,7 @@ export const Actions = ({ year = 2021 }) => {
             className="outline"
             download
             target="_blank"
-            href={`https://github.com/DevC-Casa/stateofdev.ma/blob/master/results/${year}/state-of-dev-ma-${year}.zip?raw=true`}
+            href={`https://github.com/geeksblabla/stateofdev.ma/blob/master/results/${year}/state-of-dev-ma-${year}.zip?raw=true`}
           >
             Download raw results
           </a>
@@ -36,7 +36,7 @@ export const Actions = ({ year = 2021 }) => {
             className="outline"
             download
             target="_blank"
-            href="https://github.com/DevC-Casa/stateofdev.ma/"
+            href="https://github.com/geeksblabla/stateofdev.ma"
           >
             Write an article
           </a>


### PR DESCRIPTION
since devc-casa is gone, many URLs are still redirecting to the new "geeksblabla" github organization, I thought it might as well be renamed.